### PR TITLE
Implement postcondition DSL, i.e. #Then…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,12 @@ repositories {
 }
 
 dependencies {
+  compile 'org.hamcrest:hamcrest-core:1.3.+'
+
   testCompile 'junit:junit:4.+',
-    'org.assertj:assertj-core:3.+'
+    'org.assertj:assertj-core:3.+',
+    'org.mockito:mockito-core:2.0.43-beta',
+    'info.solidsoft.mockito:mockito-java8:2.0.0-beta'
 }
 
 compileJava {

--- a/build.gradle
+++ b/build.gradle
@@ -18,11 +18,11 @@ repositories {
 
 dependencies {
   compile 'org.hamcrest:hamcrest-core:1.3.+'
+  compile 'junit:junit:4.+'
 
-  testCompile 'junit:junit:4.+',
-    'org.assertj:assertj-core:3.+',
-    'org.mockito:mockito-core:2.0.43-beta',
-    'info.solidsoft.mockito:mockito-java8:2.0.0-beta'
+  testCompile 'org.assertj:assertj-core:3.+'
+  testCompile 'org.mockito:mockito-core:2.0.43-beta'
+  testCompile 'info.solidsoft.mockito:mockito-java8:2.0.0-beta'
 }
 
 compileJava {

--- a/src/main/java/ballad/Ballad.java
+++ b/src/main/java/ballad/Ballad.java
@@ -7,11 +7,17 @@ public class Ballad {
     return new Var<>(value);
   }
 
-  static final void recruit(Scribe scribe) {
-    Ballad.scribe.set(scribe);
+  static final void recruit(Scribe s) {
+    scribe.set(s);
   }
 
   static final Scribe scribe() {
-    return Ballad.scribe.get();
+    return scribe.get();
+  }
+
+  static final void retire(Scribe s) {
+    if (scribe.get() == s) {
+      scribe.remove();
+    }
   }
 }

--- a/src/main/java/ballad/Ballad.java
+++ b/src/main/java/ballad/Ballad.java
@@ -1,0 +1,17 @@
+package ballad;
+
+public class Ballad {
+  private static final ThreadLocal<Scribe> scribe = new ThreadLocal<>();
+
+  public static final <T> Var<T> var(T value) {
+    return new Var<>(value);
+  }
+
+  static final void recruit(Scribe scribe) {
+    Ballad.scribe.set(scribe);
+  }
+
+  static final Scribe scribe() {
+    return Ballad.scribe.get();
+  }
+}

--- a/src/main/java/ballad/Ballad.java
+++ b/src/main/java/ballad/Ballad.java
@@ -16,8 +16,6 @@ public class Ballad {
   }
 
   static final void retire(Scribe s) {
-    if (scribe.get() == s) {
-      scribe.remove();
-    }
+    if (scribe.get() == s) scribe.remove();
   }
 }

--- a/src/main/java/ballad/BalladSpec.java
+++ b/src/main/java/ballad/BalladSpec.java
@@ -1,0 +1,37 @@
+package ballad;
+
+import org.hamcrest.Matcher;
+
+public interface BalladSpec {
+  default void Then(Function<Boolean> postcondition) {
+    Ballad.scribe().recordPostcondition(postcondition);
+  }
+
+  default void Then(Procedure postcondition) {
+    Ballad.scribe().recordPostcondition(postcondition);
+  }
+
+  default <T> void Then(T value, Function1<Boolean, T> postcondition) {
+    Ballad.scribe().recordPostcondition(value, postcondition);
+  }
+
+  default <T extends Object> void Then(Var<T> var, Function1<Boolean, T> postcondition) {
+    Ballad.scribe().recordPostcondition(var, postcondition);
+  }
+
+  default <T> void Then(T value, Procedure1<T> postcondition) {
+    Ballad.scribe().recordPostcondition(value, postcondition);
+  }
+
+  default <T> void Then(Var<T> var, Procedure1<T> postcondition) {
+    Ballad.scribe().recordPostcondition(var, postcondition);
+  }
+
+  default <T extends Object> void Then(T value, Matcher<Object> matcher) {
+    Ballad.scribe().recordPostcondition(value, matcher);
+  }
+
+  default <T extends Object> void Then(Var<T> var, Matcher<Object> matcher) {
+    Ballad.scribe().recordPostcondition(var, matcher);
+  }
+}

--- a/src/main/java/ballad/BalladSpec.java
+++ b/src/main/java/ballad/BalladSpec.java
@@ -3,35 +3,35 @@ package ballad;
 import org.hamcrest.Matcher;
 
 public interface BalladSpec {
-  default void Then(Function<Boolean> postcondition) {
-    Ballad.scribe().recordPostcondition(postcondition);
+  default void Then(Function<Boolean> expression) {
+    Ballad.scribe().chroniclePostcondition(expression, PostconditionError.eager());
   }
 
-  default void Then(Procedure postcondition) {
-    Ballad.scribe().recordPostcondition(postcondition);
+  default void Then(Procedure proc) {
+    Ballad.scribe().chroniclePostcondition(proc, PostconditionError.eager());
   }
 
-  default <T> void Then(T value, Function1<Boolean, T> postcondition) {
-    Ballad.scribe().recordPostcondition(value, postcondition);
+  default <T> void Then(T value, Function1<Boolean, T> expression) {
+    Ballad.scribe().chroniclePostcondition(value, expression, PostconditionError.eager());
   }
 
-  default <T extends Object> void Then(Var<T> var, Function1<Boolean, T> postcondition) {
-    Ballad.scribe().recordPostcondition(var, postcondition);
+  default <T extends Object> void Then(Var<T> var, Function1<Boolean, T> expression) {
+    Ballad.scribe().chroniclePostcondition(var, expression, PostconditionError.eager());
   }
 
-  default <T> void Then(T value, Procedure1<T> postcondition) {
-    Ballad.scribe().recordPostcondition(value, postcondition);
+  default <T> void Then(T value, Procedure1<T> proc) {
+    Ballad.scribe().chroniclePostcondition(value, proc, PostconditionError.eager());
   }
 
-  default <T> void Then(Var<T> var, Procedure1<T> postcondition) {
-    Ballad.scribe().recordPostcondition(var, postcondition);
+  default <T> void Then(Var<T> var, Procedure1<T> proc) {
+    Ballad.scribe().chroniclePostcondition(var, proc, PostconditionError.eager());
   }
 
-  default <T extends Object> void Then(T value, Matcher<Object> matcher) {
-    Ballad.scribe().recordPostcondition(value, matcher);
+  default <T extends Object> void Then(T value, Matcher<? super T> matchExpression) {
+    Ballad.scribe().chroniclePostcondition(value, matchExpression, PostconditionError.eager());
   }
 
-  default <T extends Object> void Then(Var<T> var, Matcher<Object> matcher) {
-    Ballad.scribe().recordPostcondition(var, matcher);
+  default <T extends Object> void Then(Var<T> var, Matcher<? super T> matchExpression) {
+    Ballad.scribe().chroniclePostcondition(var, matchExpression, PostconditionError.eager());
   }
 }

--- a/src/main/java/ballad/BalladSpec.java
+++ b/src/main/java/ballad/BalladSpec.java
@@ -11,27 +11,15 @@ public interface BalladSpec {
     Ballad.scribe().chroniclePostcondition(proc, PostconditionError.eager());
   }
 
-  default <T> void Then(T value, Function1<Boolean, T> expression) {
-    Ballad.scribe().chroniclePostcondition(value, expression, PostconditionError.eager());
-  }
-
-  default <T extends Object> void Then(Var<T> var, Function1<Boolean, T> expression) {
+  default <S, T extends S> void Then(Var<T> var, Function1<Boolean, S> expression) {
     Ballad.scribe().chroniclePostcondition(var, expression, PostconditionError.eager());
   }
 
-  default <T> void Then(T value, Procedure1<T> proc) {
-    Ballad.scribe().chroniclePostcondition(value, proc, PostconditionError.eager());
-  }
-
-  default <T> void Then(Var<T> var, Procedure1<T> proc) {
+  default <S, T extends S> void Then(Var<T> var, Procedure1<S> proc) {
     Ballad.scribe().chroniclePostcondition(var, proc, PostconditionError.eager());
   }
 
-  default <T extends Object> void Then(T value, Matcher<? super T> matchExpression) {
-    Ballad.scribe().chroniclePostcondition(value, matchExpression, PostconditionError.eager());
-  }
-
-  default <T extends Object> void Then(Var<T> var, Matcher<? super T> matchExpression) {
+  default <S, T extends S> void Then(Var<T> var, Matcher<S> matchExpression) {
     Ballad.scribe().chroniclePostcondition(var, matchExpression, PostconditionError.eager());
   }
 }

--- a/src/main/java/ballad/Balladeer.java
+++ b/src/main/java/ballad/Balladeer.java
@@ -1,0 +1,55 @@
+package ballad;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.ParentRunner;
+import org.junit.runners.model.InitializationError;
+
+public class Balladeer extends ParentRunner<Postcondition> {
+  private final List<Postcondition> accumulator;
+
+  public Balladeer(Class<?> testClass) throws InitializationError {
+    this(new ArrayList<Postcondition>(), testClass);
+  }
+
+  private Balladeer(List<Postcondition> acc, Class<?> testClass) throws InitializationError {
+    this(new RecordingScribe(acc), acc, testClass);
+  }
+
+  Balladeer(Scribe s, List<Postcondition> acc, Class<?> testClass) throws InitializationError {
+    super(testClass);
+    Ballad.recruit(s);
+    try {
+      testClass.newInstance();
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new InitializationError(e);
+    }
+    this.accumulator = acc;
+    Ballad.retire(s);
+  }
+
+  @Override
+  protected List<Postcondition> getChildren() {
+    return accumulator;
+  }
+
+  @Override
+  protected Description describeChild(Postcondition postcondition) {
+    return Description.createTestDescription(getTestClass().getJavaClass(),
+        String.format("Then… (%d)", postcondition.hashCode()));
+  }
+
+  @Override
+  protected void runChild(Postcondition postcondition, RunNotifier notifier) {
+    final Description desc = describeChild(postcondition);
+    notifier.fireTestStarted(desc);
+    try {
+      postcondition.verify();
+    } catch (final AssertionError e) {
+      notifier.fireTestFailure(new Failure(desc, e));
+    }
+  }
+}

--- a/src/main/java/ballad/Function.java
+++ b/src/main/java/ballad/Function.java
@@ -1,0 +1,6 @@
+package ballad;
+
+@FunctionalInterface
+public interface Function<T> {
+  public T invoke();
+}

--- a/src/main/java/ballad/Function1.java
+++ b/src/main/java/ballad/Function1.java
@@ -1,0 +1,6 @@
+package ballad;
+
+@FunctionalInterface
+public interface Function1<T, U> {
+  public T invoke(U u);
+}

--- a/src/main/java/ballad/Postcondition.java
+++ b/src/main/java/ballad/Postcondition.java
@@ -1,0 +1,5 @@
+package ballad;
+
+public interface Postcondition {
+  void verify();
+}

--- a/src/main/java/ballad/PostconditionError.java
+++ b/src/main/java/ballad/PostconditionError.java
@@ -1,0 +1,37 @@
+package ballad;
+
+import java.util.Arrays;
+import org.hamcrest.Description;
+
+class PostconditionError extends AssertionError {
+  private static final long serialVersionUID = -3383182470908582913L;
+
+  static final PostconditionError eager() {
+    final PostconditionError e = new PostconditionError();
+    final StackTraceElement[] a = e.getStackTrace();
+    e.setStackTrace(Arrays.copyOfRange(a, 2, a.length, a.getClass()));
+    return e;
+  }
+
+  private PostconditionError() {
+    this("postcondition not met");
+  }
+
+  private PostconditionError(String message, AssertionError cause) {
+    super(message, cause);
+  }
+
+  PostconditionError(PostconditionError eager, AssertionError cause) {
+    this(eager.getMessage(), cause);
+    setStackTrace(eager.getStackTrace());
+  }
+
+  PostconditionError(String message) {
+    super(message);
+  }
+
+  PostconditionError(PostconditionError eager, Description description) {
+    this(String.format("postcondition not met%s", description.toString()));
+    setStackTrace(eager.getStackTrace());
+  }
+}

--- a/src/main/java/ballad/Procedure.java
+++ b/src/main/java/ballad/Procedure.java
@@ -1,0 +1,6 @@
+package ballad;
+
+@FunctionalInterface
+public interface Procedure {
+  void invoke() throws AssertionError;
+}

--- a/src/main/java/ballad/Procedure1.java
+++ b/src/main/java/ballad/Procedure1.java
@@ -1,0 +1,6 @@
+package ballad;
+
+@FunctionalInterface
+public interface Procedure1<T> {
+  void invoke(T t) throws AssertionError;
+}

--- a/src/main/java/ballad/RecordingScribe.java
+++ b/src/main/java/ballad/RecordingScribe.java
@@ -31,32 +31,14 @@ public class RecordingScribe implements Scribe {
   }
 
   @Override
-  public <T> void chroniclePostcondition(T value, Function1<Boolean, T> expression, PostconditionError eager) {
-    accumulator.add(() -> {
-      if (!expression.invoke(value)) throw eager;
-    });
-  }
-
-  @Override
-  public <T> void chroniclePostcondition(Var<T> var, Function1<Boolean, T> expression, PostconditionError eager) {
+  public <S, T extends S> void chroniclePostcondition(Var<T> var, Function1<Boolean, S> expression, PostconditionError eager) {
     accumulator.add(() -> {
       if (!expression.invoke(var.get())) throw eager;
     });
   }
 
   @Override
-  public <T> void chroniclePostcondition(T value, Procedure1<T> proc, PostconditionError eager) {
-    accumulator.add(() -> {
-      try {
-        proc.invoke(value);
-      } catch (final AssertionError cause) {
-        throw new PostconditionError(eager, cause);
-      }
-    });
-  }
-
-  @Override
-  public <T> void chroniclePostcondition(Var<T> var, Procedure1<T> proc, PostconditionError eager) {
+  public <S, T extends S> void chroniclePostcondition(Var<T> var, Procedure1<S> proc, PostconditionError eager) {
     accumulator.add(() -> {
       try {
         proc.invoke(var.get());
@@ -67,25 +49,12 @@ public class RecordingScribe implements Scribe {
   }
 
   @Override
-  public <T> void chroniclePostcondition(T value, Matcher<? super T> matchExpression, PostconditionError eager) {
-    accumulator.add(() -> {
-      if (!matchExpression.matches(value)) {
-        final Description description = new StringDescription();
-        description.appendText("").appendText("\nExpected: ").appendDescriptionOf(matchExpression)
-            .appendText("\n     but: ");
-        matchExpression.describeMismatch(value, description);
-        throw new PostconditionError(eager, description);
-      }
-    });
-  }
-
-  @Override
-  public <T> void chroniclePostcondition(Var<T> var, Matcher<? super T> matchExpression, PostconditionError eager) {
+  public <S, T extends S> void chroniclePostcondition(Var<T> var, Matcher<S> matchExpression, PostconditionError eager) {
     accumulator.add(() -> {
       if (!matchExpression.matches(var.get())) {
         final Description description = new StringDescription();
         description.appendText("").appendText("\nExpected: ").appendDescriptionOf(matchExpression)
-            .appendText("\n     but: ");
+        .appendText("\n     but: ");
         matchExpression.describeMismatch(var.get(), description);
         throw new PostconditionError(eager, description);
       }

--- a/src/main/java/ballad/RecordingScribe.java
+++ b/src/main/java/ballad/RecordingScribe.java
@@ -1,0 +1,94 @@
+package ballad;
+
+import java.util.Collection;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.StringDescription;
+
+public class RecordingScribe implements Scribe {
+  private final Collection<Postcondition> accumulator;
+
+  RecordingScribe(Collection<Postcondition> acc) {
+    this.accumulator = acc;
+  }
+
+  @Override
+  public void chroniclePostcondition(Function<Boolean> expression, PostconditionError eager) {
+    accumulator.add(() -> {
+      if (!expression.invoke()) throw eager;
+    });
+  }
+
+  @Override
+  public void chroniclePostcondition(Procedure proc, PostconditionError eager) {
+    accumulator.add(() -> {
+      try {
+        proc.invoke();
+      } catch (final AssertionError cause) {
+        throw new PostconditionError(eager, cause);
+      }
+    });
+  }
+
+  @Override
+  public <T> void chroniclePostcondition(T value, Function1<Boolean, T> expression, PostconditionError eager) {
+    accumulator.add(() -> {
+      if (!expression.invoke(value)) throw eager;
+    });
+  }
+
+  @Override
+  public <T> void chroniclePostcondition(Var<T> var, Function1<Boolean, T> expression, PostconditionError eager) {
+    accumulator.add(() -> {
+      if (!expression.invoke(var.get())) throw eager;
+    });
+  }
+
+  @Override
+  public <T> void chroniclePostcondition(T value, Procedure1<T> proc, PostconditionError eager) {
+    accumulator.add(() -> {
+      try {
+        proc.invoke(value);
+      } catch (final AssertionError cause) {
+        throw new PostconditionError(eager, cause);
+      }
+    });
+  }
+
+  @Override
+  public <T> void chroniclePostcondition(Var<T> var, Procedure1<T> proc, PostconditionError eager) {
+    accumulator.add(() -> {
+      try {
+        proc.invoke(var.get());
+      } catch (final AssertionError cause) {
+        throw new PostconditionError(eager, cause);
+      }
+    });
+  }
+
+  @Override
+  public <T> void chroniclePostcondition(T value, Matcher<? super T> matchExpression, PostconditionError eager) {
+    accumulator.add(() -> {
+      if (!matchExpression.matches(value)) {
+        final Description description = new StringDescription();
+        description.appendText("").appendText("\nExpected: ").appendDescriptionOf(matchExpression)
+            .appendText("\n     but: ");
+        matchExpression.describeMismatch(value, description);
+        throw new PostconditionError(eager, description);
+      }
+    });
+  }
+
+  @Override
+  public <T> void chroniclePostcondition(Var<T> var, Matcher<? super T> matchExpression, PostconditionError eager) {
+    accumulator.add(() -> {
+      if (!matchExpression.matches(var.get())) {
+        final Description description = new StringDescription();
+        description.appendText("").appendText("\nExpected: ").appendDescriptionOf(matchExpression)
+            .appendText("\n     but: ");
+        matchExpression.describeMismatch(var.get(), description);
+        throw new PostconditionError(eager, description);
+      }
+    });
+  }
+}

--- a/src/main/java/ballad/Scribe.java
+++ b/src/main/java/ballad/Scribe.java
@@ -2,20 +2,21 @@ package ballad;
 
 import org.hamcrest.Matcher;
 
-public interface Scribe {
-  void recordPostcondition(Function<Boolean> postcondition);
+interface Scribe {
+  void chroniclePostcondition(Function<Boolean> expression, PostconditionError eager);
 
-  void recordPostcondition(Procedure postcondition);
+  void chroniclePostcondition(Procedure proc, PostconditionError eager);
 
-  <T> void recordPostcondition(T value, Function1<Boolean, T> postcondition);
+  <T> void chroniclePostcondition(T value, Function1<Boolean, T> expression, PostconditionError eager);
 
-  <T> void recordPostcondition(Var<T> var, Function1<Boolean, T> postcondition);
+  <T> void chroniclePostcondition(Var<T> var, Function1<Boolean, T> expression, PostconditionError eager);
 
-  <T> void recordPostcondition(T value, Procedure1<T> postcondition);
+  <T> void chroniclePostcondition(T value, Procedure1<T> proc, PostconditionError eager);
 
-  <T> void recordPostcondition(Var<T> value, Procedure1<T> postcondition);
+  <T> void chroniclePostcondition(Var<T> var, Procedure1<T> proc, PostconditionError eager);
 
-  <T extends Object> void recordPostcondition(T value, Matcher<Object> matcher);
+  <T extends Object> void chroniclePostcondition(T value, Matcher<? super T> matchExpression, PostconditionError eager);
 
-  <T extends Object> void recordPostcondition(Var<T> var, Matcher<Object> matcher);
+  <T extends Object> void chroniclePostcondition(Var<T> var, Matcher<? super T> matchExpression,
+      PostconditionError eager);
 }

--- a/src/main/java/ballad/Scribe.java
+++ b/src/main/java/ballad/Scribe.java
@@ -7,16 +7,9 @@ interface Scribe {
 
   void chroniclePostcondition(Procedure proc, PostconditionError eager);
 
-  <T> void chroniclePostcondition(T value, Function1<Boolean, T> expression, PostconditionError eager);
+  <S, T extends S> void chroniclePostcondition(Var<T> var, Function1<Boolean, S> expression, PostconditionError eager);
 
-  <T> void chroniclePostcondition(Var<T> var, Function1<Boolean, T> expression, PostconditionError eager);
+  <S, T extends S> void chroniclePostcondition(Var<T> var, Procedure1<S> proc, PostconditionError eager);
 
-  <T> void chroniclePostcondition(T value, Procedure1<T> proc, PostconditionError eager);
-
-  <T> void chroniclePostcondition(Var<T> var, Procedure1<T> proc, PostconditionError eager);
-
-  <T extends Object> void chroniclePostcondition(T value, Matcher<? super T> matchExpression, PostconditionError eager);
-
-  <T extends Object> void chroniclePostcondition(Var<T> var, Matcher<? super T> matchExpression,
-      PostconditionError eager);
+  <S, T extends S> void chroniclePostcondition(Var<T> var, Matcher<S> matchExpression, PostconditionError eager);
 }

--- a/src/main/java/ballad/Scribe.java
+++ b/src/main/java/ballad/Scribe.java
@@ -1,0 +1,21 @@
+package ballad;
+
+import org.hamcrest.Matcher;
+
+public interface Scribe {
+  void recordPostcondition(Function<Boolean> postcondition);
+
+  void recordPostcondition(Procedure postcondition);
+
+  <T> void recordPostcondition(T value, Function1<Boolean, T> postcondition);
+
+  <T> void recordPostcondition(Var<T> var, Function1<Boolean, T> postcondition);
+
+  <T> void recordPostcondition(T value, Procedure1<T> postcondition);
+
+  <T> void recordPostcondition(Var<T> value, Procedure1<T> postcondition);
+
+  <T extends Object> void recordPostcondition(T value, Matcher<Object> matcher);
+
+  <T extends Object> void recordPostcondition(Var<T> var, Matcher<Object> matcher);
+}

--- a/src/main/java/ballad/Var.java
+++ b/src/main/java/ballad/Var.java
@@ -1,0 +1,22 @@
+package ballad;
+
+public final class Var<T> {
+  private T value;
+
+  Var(T value) {
+    this.value = value;
+  }
+
+  public T get() {
+    return value;
+  }
+
+  public void set(T value) {
+    this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("Var❪%s❫", value);
+  }
+}

--- a/src/test/java/SampleSpec.java
+++ b/src/test/java/SampleSpec.java
@@ -1,0 +1,40 @@
+
+import static ballad.Ballad.var;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import org.junit.runner.RunWith;
+import ballad.BalladSpec;
+import ballad.Balladeer;
+import ballad.Var;
+
+@RunWith(Balladeer.class)
+public class SampleSpec implements BalladSpec {
+  {
+    final Var<Integer> intVar = var(2);
+    final Var<String> stringVar = var("eep");
+
+    Then(() -> false);
+
+    Then(() -> {
+      fail("boom");
+    });
+
+    Then(2, (i) -> i < 2);
+
+    Then(intVar, (Integer i) -> i > 2);
+
+    Then(13, i -> {
+      assertThat(i, equalTo(42));
+    });
+
+    Then(13, equalTo(42));
+
+    Then(stringVar, (String s) -> {
+      assertThat(s, startsWith("sl"));
+    });
+
+    Then(stringVar, startsWith("sl"));
+  }
+}

--- a/src/test/java/SampleSpec.java
+++ b/src/test/java/SampleSpec.java
@@ -10,31 +10,26 @@ import ballad.Balladeer;
 import ballad.Var;
 
 @RunWith(Balladeer.class)
-public class SampleSpec implements BalladSpec {
-  {
-    final Var<Integer> intVar = var(2);
-    final Var<String> stringVar = var("eep");
+public class SampleSpec implements BalladSpec {{
+  final Var<Integer> intVar = var(2);
+  final Var<String> stringVar = var("eep");
 
-    Then(() -> false);
+  Then(() -> false); // FAIL
 
-    Then(() -> {
-      fail("boom");
-    });
+  Then(() -> {
+    fail("boom");
+  }); // FAIL
 
-    Then(2, (i) -> i < 2);
+  Then(intVar, (Integer i) -> i > 2); // FAIL
 
-    Then(intVar, (Integer i) -> i > 2);
+  Then(intVar, i -> {
+    assertThat(i, equalTo(42));
+  }); // FAIL
 
-    Then(13, i -> {
-      assertThat(i, equalTo(42));
-    });
+  Then(stringVar, (String s) -> {
+    assertThat(s, startsWith("sl"));
+  }); // FAIL
 
-    Then(13, equalTo(42));
-
-    Then(stringVar, (String s) -> {
-      assertThat(s, startsWith("sl"));
-    });
-
-    Then(stringVar, startsWith("sl"));
-  }
-}
+  Then(stringVar, startsWith("sl")); // FAIL
+  Then(stringVar, equalTo("eep"));   // PASS
+}}

--- a/src/test/java/ballad/BalladSpecTest.java
+++ b/src/test/java/ballad/BalladSpecTest.java
@@ -1,7 +1,6 @@
 package ballad;
 
 import static ballad.Ballad.var;
-import static org.hamcrest.CoreMatchers.anything;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
 import org.junit.Before;
@@ -39,7 +38,7 @@ public class BalladSpecTest implements WithMockito {
   @Test
   public void proceduralPostcondition() {
     final Procedure postcondition = () -> {
-      assert (2 != 3);
+      assert 2 != 3;
     };
 
     new BalladSpec() {
@@ -49,20 +48,6 @@ public class BalladSpecTest implements WithMockito {
     };
 
     verify(scribe).chroniclePostcondition(eq(postcondition), anyPostconditionError());
-  }
-
-  @Test
-  public void valueAndBooleanPostcondition() {
-    final int value = 42;
-    final Function1<Boolean, Integer> postcondition = (v) -> v > 0;
-
-    new BalladSpec() {
-      {
-        Then(value, postcondition);
-      }
-    };
-
-    verify(scribe).chroniclePostcondition(eq(value), eq(postcondition), anyPostconditionError());
   }
 
   @Test
@@ -80,26 +65,10 @@ public class BalladSpecTest implements WithMockito {
   }
 
   @Test
-  public void valueAndProceduralPostcondition() {
-    final int value = 42;
-    final Procedure1<Integer> postcondition = (v) -> {
-      assert (v > 0);
-    };
-
-    new BalladSpec() {
-      {
-        Then(value, postcondition);
-      }
-    };
-
-    verify(scribe).chroniclePostcondition(eq(value), eq(postcondition), anyPostconditionError());
-  }
-
-  @Test
   public void varAndProceduralPostcondition() {
     final Var<Integer> value = var(42);
     final Procedure1<Integer> postcondition = (v) -> {
-      assert (v > 0);
+      assert v > 0;
     };
 
     new BalladSpec() {
@@ -109,20 +78,6 @@ public class BalladSpecTest implements WithMockito {
     };
 
     verify(scribe).chroniclePostcondition(eq(value), eq(postcondition), anyPostconditionError());
-  }
-
-  @Test
-  public void valueAndMatcherPostcondition() {
-    final String value = "whatever";
-    final Matcher<Object> isAnything = anything("match anything");
-
-    new BalladSpec() {
-      {
-        Then(value, isAnything);
-      }
-    };
-
-    verify(scribe).chroniclePostcondition(eq(value), eq(isAnything), anyPostconditionError());
   }
 
   @Test

--- a/src/test/java/ballad/BalladSpecTest.java
+++ b/src/test/java/ballad/BalladSpecTest.java
@@ -2,6 +2,7 @@ package ballad;
 
 import static ballad.Ballad.var;
 import static org.hamcrest.CoreMatchers.anything;
+import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Rule;
@@ -32,7 +33,7 @@ public class BalladSpecTest implements WithMockito {
       }
     };
 
-    verify(scribe).recordPostcondition(postcondition);
+    verify(scribe).chroniclePostcondition(eq(postcondition), anyPostconditionError());
   }
 
   @Test
@@ -47,7 +48,7 @@ public class BalladSpecTest implements WithMockito {
       }
     };
 
-    verify(scribe).recordPostcondition(postcondition);
+    verify(scribe).chroniclePostcondition(eq(postcondition), anyPostconditionError());
   }
 
   @Test
@@ -61,7 +62,7 @@ public class BalladSpecTest implements WithMockito {
       }
     };
 
-    verify(scribe).recordPostcondition(value, postcondition);
+    verify(scribe).chroniclePostcondition(eq(value), eq(postcondition), anyPostconditionError());
   }
 
   @Test
@@ -75,7 +76,7 @@ public class BalladSpecTest implements WithMockito {
       }
     };
 
-    verify(scribe).recordPostcondition(value, postcondition);
+    verify(scribe).chroniclePostcondition(eq(value), eq(postcondition), anyPostconditionError());
   }
 
   @Test
@@ -91,7 +92,7 @@ public class BalladSpecTest implements WithMockito {
       }
     };
 
-    verify(scribe).recordPostcondition(value, postcondition);
+    verify(scribe).chroniclePostcondition(eq(value), eq(postcondition), anyPostconditionError());
   }
 
   @Test
@@ -107,7 +108,7 @@ public class BalladSpecTest implements WithMockito {
       }
     };
 
-    verify(scribe).recordPostcondition(value, postcondition);
+    verify(scribe).chroniclePostcondition(eq(value), eq(postcondition), anyPostconditionError());
   }
 
   @Test
@@ -121,13 +122,13 @@ public class BalladSpecTest implements WithMockito {
       }
     };
 
-    verify(scribe).recordPostcondition(value, isAnything);
+    verify(scribe).chroniclePostcondition(eq(value), eq(isAnything), anyPostconditionError());
   }
 
   @Test
   public void varAndMatcherPostcondition() {
     final Var<String> var = var("whatever");
-    final Matcher<Object> isAnything = anything("match anything");
+    final Matcher<String> isAnything = CoreMatchers.any(String.class);
 
     new BalladSpec() {
       {
@@ -135,6 +136,10 @@ public class BalladSpecTest implements WithMockito {
       }
     };
 
-    verify(scribe).recordPostcondition(var, isAnything);
+    verify(scribe).chroniclePostcondition(eq(var), eq(isAnything), anyPostconditionError());
+  }
+
+  private PostconditionError anyPostconditionError() {
+    return any(PostconditionError.class);
   }
 }

--- a/src/test/java/ballad/BalladSpecTest.java
+++ b/src/test/java/ballad/BalladSpecTest.java
@@ -1,0 +1,140 @@
+package ballad;
+
+import static ballad.Ballad.var;
+import static org.hamcrest.CoreMatchers.anything;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import info.solidsoft.mockito.java8.api.WithMockito;
+
+public class BalladSpecTest implements WithMockito {
+  @Rule
+  public MockitoRule mockito = MockitoJUnit.rule();
+  @Mock
+  private Scribe scribe;
+
+  @Before
+  public void recruitScribe() {
+    Ballad.recruit(scribe);
+  }
+
+  @Test
+  public void booleanPostcondition() {
+    final Function<Boolean> postcondition = () -> 2 != 3;
+
+    new BalladSpec() {
+      {
+        Then(postcondition);
+      }
+    };
+
+    verify(scribe).recordPostcondition(postcondition);
+  }
+
+  @Test
+  public void proceduralPostcondition() {
+    final Procedure postcondition = () -> {
+      assert (2 != 3);
+    };
+
+    new BalladSpec() {
+      {
+        Then(postcondition);
+      }
+    };
+
+    verify(scribe).recordPostcondition(postcondition);
+  }
+
+  @Test
+  public void valueAndBooleanPostcondition() {
+    final int value = 42;
+    final Function1<Boolean, Integer> postcondition = (v) -> v > 0;
+
+    new BalladSpec() {
+      {
+        Then(value, postcondition);
+      }
+    };
+
+    verify(scribe).recordPostcondition(value, postcondition);
+  }
+
+  @Test
+  public void varAndBooleanPostcondition() {
+    final Var<Integer> value = var(42);
+    final Function1<Boolean, Integer> postcondition = (v) -> v > 0;
+
+    new BalladSpec() {
+      {
+        Then(value, postcondition);
+      }
+    };
+
+    verify(scribe).recordPostcondition(value, postcondition);
+  }
+
+  @Test
+  public void valueAndProceduralPostcondition() {
+    final int value = 42;
+    final Procedure1<Integer> postcondition = (v) -> {
+      assert (v > 0);
+    };
+
+    new BalladSpec() {
+      {
+        Then(value, postcondition);
+      }
+    };
+
+    verify(scribe).recordPostcondition(value, postcondition);
+  }
+
+  @Test
+  public void varAndProceduralPostcondition() {
+    final Var<Integer> value = var(42);
+    final Procedure1<Integer> postcondition = (v) -> {
+      assert (v > 0);
+    };
+
+    new BalladSpec() {
+      {
+        Then(value, postcondition);
+      }
+    };
+
+    verify(scribe).recordPostcondition(value, postcondition);
+  }
+
+  @Test
+  public void valueAndMatcherPostcondition() {
+    final String value = "whatever";
+    final Matcher<Object> isAnything = anything("match anything");
+
+    new BalladSpec() {
+      {
+        Then(value, isAnything);
+      }
+    };
+
+    verify(scribe).recordPostcondition(value, isAnything);
+  }
+
+  @Test
+  public void varAndMatcherPostcondition() {
+    final Var<String> var = var("whatever");
+    final Matcher<Object> isAnything = anything("match anything");
+
+    new BalladSpec() {
+      {
+        Then(var, isAnything);
+      }
+    };
+
+    verify(scribe).recordPostcondition(var, isAnything);
+  }
+}


### PR DESCRIPTION
* [ ] Postcondition DSL
  * [x] `Then(() -> boolean expression)`
  * [x] `Then(() -> { assertions })`
  * [x] `Then(Var<>, v -> boolean expression)`
  * [x] `Then(Var<>, v -> { assertions })`
  * [x] `Then(Var<>, Matcher<>)`
* [x] a JUnit4 runner that surfaces postconditions as individual tests
* [ ] tweak `AssertionError` stack traces
  * [x] hide Ballad internals
  * [x] top frame of the stack trace should take you to the line of the failing assertion
  * [ ] weave the `Then` declaration into the trace
* [x] fix ballad specs compilation errors around `Then(T, Matcher<T>)` and `Then(Var<T>, Matcher<T>)` ambiguity when matcher is also generic