### PR TITLE
Hide Gradle and Eclipse build dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 .classpath
 .project
 .settings/
-build/

--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,10 @@ test {
   }
 }
 
-eclipse {
-  classpath {
-    defaultOutputDir = file('build/eclipse')
+allprojects {
+  eclipse {
+    classpath {
+      defaultOutputDir = file('.gradle/build/eclipse')
+    }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+buildDir=.gradle/build/gradle


### PR DESCRIPTION
* [x] free up `bin/` for executable scripts
* [x] consolidate Gradle and Eclipse under common directory
* [x] move gradle and Eclipse build dirs under .gradle/

Since `.gradle` is already hidden and in `.gitignore` this
seems ideal; analagous to stuffing things under `.bundle/`.